### PR TITLE
Adding PREFIX variable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,24 +4,24 @@
 RESOURCE = ./resource
 BIN = ./bin
 SRC = ./src
+PREFIX = 
 
 linux_x64:
-	cp $(RESOURCE)/skype.png /usr/share/icons/hicolor/512x512/apps/
+	cp $(RESOURCE)/skype.png $(PREFIX)/usr/share/icons/hicolor/512x512/apps/
 	cp $(SRC)/package.json $(BIN)/linux_x64
-	mkdir -p /opt/skype_unofficial_client
-	cp -R $(BIN)/linux_x64/* /opt/skype_unofficial_client
-	chmod +x -R /opt/skype_unofficial_client
-	cp $(SRC)/Skype.desktop /usr/share/applications
-	cp $(SRC)/skype-desktop /usr/bin
-	chmod +x $(SRC)/skype-desktop 
+	mkdir -p $(PREFIX)/opt/skype_unofficial_client
+	cp -R $(BIN)/linux_x64/* $(PREFIX)/opt/skype_unofficial_client
+	chmod +x -R $(PREFIX)/opt/skype_unofficial_client
+	cp $(SRC)/Skype.desktop $(PREFIX)/usr/share/applications
+	chmod +x $(SRC)/skype-desktop
+	cp $(SRC)/skype-desktop $(PREFIX)/usr/bin
          
 linux_x86:
-	cp $(RESOURCE)/skype.png /usr/share/icons/hicolor/512x512/apps/
+	cp $(RESOURCE)/skype.png $(PREFIX)/usr/share/icons/hicolor/512x512/apps/
 	cp $(SRC)/package.json $(BIN)/linux_x86
-	mkdir -p /opt/skype_unofficial_client
-	cp -R $(BIN)/linux_x86/* /opt/skype_unofficial_client
-	chmod +x -R /opt/skype_unofficial_client
-	cp $(SRC)/Skype.desktop /usr/share/applications
-	cp $(SRC)/skype-desktop /usr/bin
-	chmod +x $(SRC)/skype-desktop 
- 
+	mkdir -p $(PREFIX)/opt/skype_unofficial_client
+	cp -R $(BIN)/linux_x86/* $(PREFIX)/opt/skype_unofficial_client
+	chmod +x -R $(PREFIX)/opt/skype_unofficial_client
+	cp $(SRC)/Skype.desktop $(PREFIX)/usr/share/applications
+	chmod +x $(SRC)/skype-desktop
+	cp $(SRC)/skype-desktop $(PREFIX)/usr/bin


### PR DESCRIPTION
Allows users to install in a different (root!) path, useful for packaging.
